### PR TITLE
Improved C++ options handling

### DIFF
--- a/sample.js
+++ b/sample.js
@@ -23,7 +23,9 @@ options = {
   algorithm: "LD_MMA",
   numberOfParameters:2,
   minObjectiveFunction: myfunc,
+  maxObjectiveFunction: undefined,
   inequalityConstraints:[createMyConstraint([2.0, 0.0]), createMyConstraint([-1.0, 1.0])],
+  equalityConstraints: null,
   xToleranceRelative:1e-4,
   initialGuess:[1.234, 5.678],
   lowerBounds:[Number.MIN_VALUE, 0]


### PR DESCRIPTION
Couple of changes:
1. Complain if user supplies both min and max optimisation functions
2. For all parameters, treat them as unsupplied if they are either:
    * not supplied
    * supplied but undefined
    * equal to null

The old behaviour was to handle the unsupplied case differently from supplied but undefined, which is very unjavascript-like and quite hard to cope with as a user 